### PR TITLE
Fix scrolling on publication view pages.

### DIFF
--- a/apps/publisher/views.py
+++ b/apps/publisher/views.py
@@ -401,17 +401,17 @@ def view(request, project_name="all"):
             prev_articles = publications_to_load*scroll_count
             new_articles = publications_to_load*(scroll_count+1)
             if page_filter == 'all':
-                pubs["scroll_link"] = "/?type={}&scroll_count={}".format(page_filter, scroll_count + 1)
+                pubs["scroll_link"] = "?type={}&scroll_count={}".format(page_filter, scroll_count + 1)
             else:
-                pubs["scroll_link"] = "/?type={}&option={}&scroll_count={}".format(page_filter, option.replace(' ', '%20'), scroll_count + 1)
+                pubs["scroll_link"] = "?type={}&option={}&scroll_count={}".format(page_filter, option.replace(' ', '%20'), scroll_count + 1)
             pubs["publications"] = publications[prev_articles:new_articles]
             return render(request, 'snippets/load_publications.html', pubs)
 
         else:
             if page_filter == 'all':
-                pubs["scroll_link"] = "/?type={}&scroll_count=1".format(page_filter)
+                pubs["scroll_link"] = "?type={}&scroll_count=1".format(page_filter)
             else:
-                pubs["scroll_link"] = "/?type={}&option={}&scroll_count=1".format(page_filter, option.replace(' ', '%20'))
+                pubs["scroll_link"] = "?type={}&option={}&scroll_count=1".format(page_filter, option.replace(' ', '%20'))
             pubs["publications"] = publications[:publications_to_load]
     return render(request, 'site/view.html', pubs)
 


### PR DESCRIPTION
Fixes #73 

The issue was being caused by a typo in the scroll_link used to scroll publication entries on the view pages.  The inclusion of a '/' at the beginning caused the scroll link to look at the domain URL instead of the directory for the project.  This caused the scroll to load from all publications instead of the current project.

e.g. the CMIP6 page scroll will load from
`https://cmip-publications.llnl.gov/?type=all&scroll_count=1`
when it should be loading from
`https://cmip-publications.llnl.gov/view/CMIP6/?type=all&scroll_count=1`