### PR TITLE
Maintenance banner for downtime for site upgrades

### DIFF
--- a/templates/site/nav.html
+++ b/templates/site/nav.html
@@ -3,8 +3,8 @@
     <div class="container-fluid">
         <h4>
         <b>
-            Due to scheduled maintenance, a website outage will occur from noon Friday 4th October 2019
-            through early morning Monday 7th October 2019.  Apologies in advance for any inconvenience.
+            This site will be down on Wednesday, February 12, 2020 from 1 PM to 3 PM PST for site upgrades.  <br>
+            Apologies in advance for any inconvenience.
         </b>
         </h4>
     </div>

--- a/templates/site/nav.html
+++ b/templates/site/nav.html
@@ -1,6 +1,14 @@
 <!-- Static navbar -->
 <nav class="navbar navbar-default">
     <div class="container-fluid">
+        <h4>
+        <b>
+            Due to scheduled maintenance, a website outage will occur from noon Friday 4th October 2019
+            through early morning Monday 7th October 2019.  Apologies in advance for any inconvenience.
+        </b>
+        </h4>
+    </div>
+    <div class="container-fluid">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar"
                     aria-expanded="false" aria-controls="navbar">


### PR DESCRIPTION
@durack1 This will add a message to the top of the page warning users of down time for site upgrades next Wednesday.
![Screenshot_2020-02-06 Publication Hub](https://user-images.githubusercontent.com/42009431/73995208-c4e50500-490c-11ea-918a-ad2186a8b192.png)
