### PR TITLE
Add footer with info to meet compliance

### DIFF
--- a/pubhub-static/css/base.css
+++ b/pubhub-static/css/base.css
@@ -13,7 +13,7 @@ html, body {
     margin: 0 auto 4em;
 }
 
-.footer, .push {
+.push {
     height: 1em;
 }
 

--- a/pubhub-static/css/base.css
+++ b/pubhub-static/css/base.css
@@ -10,11 +10,25 @@ html, body {
     min-height: 100%;
     height: auto !important;
     height: 100%;
-    margin: 0 auto 0em;
+    margin: 0 auto 4em;
 }
 
 .footer, .push {
     height: 1em;
+}
+
+.footer {
+    position: fixed;
+    left: 0em;
+    bottom: 0em;
+    padding: 0.5em;
+    height: auto;
+    width: 100%;
+    background-color: #e7e7e7;;
+}
+
+.footer p {
+    margin: 0em;
 }
 
 div.navbar-header>a.navbar-brand,

--- a/templates/site/footer.html
+++ b/templates/site/footer.html
@@ -1,4 +1,4 @@
 <footer>
-    <p>Please report any problems on our <a href="https://github.com/PCMDI/cmip6-publication-site/issues">Github Issues</a> page.</p>
+    <p>Please report any problems on our <a href="https://github.com/PCMDI/cmip6-publication-site/issues">Github Issues</a> page. | <a href="https://www.llnl.gov/disclaimer">Privacy & Legal Notice</a></p>
     <a href="http://glyphicons.com/" style="display: none">Special Thanks glypicons</a>
 </footer>

--- a/templates/site/footer.html
+++ b/templates/site/footer.html
@@ -1,4 +1,9 @@
 <footer>
-    <p>Please report any problems on our <a href="https://github.com/PCMDI/cmip6-publication-site/issues">Github Issues</a> page. | <a href="https://www.llnl.gov/disclaimer">Privacy & Legal Notice</a></p>
+    <p>
+        Please report any problems on our <a href="https://github.com/PCMDI/cmip6-publication-site/issues">Github Issues</a> page. <br>
+        <small>
+            Prepared by <a href="https://www.llnl.gov">Lawrence Livermore National Laboratory</a> under Contract DE-AC52-07NA27344 | <a href="https://www.llnl.gov/disclaimer">Privacy & Legal Notice</a> | LLNL-WEB-XXXXXX
+        </small>
+    </p>
     <a href="http://glyphicons.com/" style="display: none">Special Thanks glypicons</a>
 </footer>


### PR DESCRIPTION
Resolves #134 

Add a footer to the website that contains a link to the LLNL website, auspices, privacy and legal notice link, and IM number.  The IM number is currently a placeholder until the real one is created.
![Screenshot_2021-06-08 Login(2)](https://user-images.githubusercontent.com/42009431/121260621-6a441c00-c866-11eb-88ca-bb30a61f6881.png)
