### PR TITLE
Fix create account button in Chrome

### DIFF
--- a/pubhub-static/css/base.css
+++ b/pubhub-static/css/base.css
@@ -11,6 +11,7 @@ html, body {
     height: auto !important;
     height: 100%;
     margin: 0 auto 4em;
+    padding-bottom: 8em;
 }
 
 .push {


### PR DESCRIPTION
Fixes #144 

An issue with the bottom margin in Chrome was preventing the "Create Account" button from showing up.  This change applies some padding to the bottom to make the button scroll past the footer.