### PR TITLE
Add VDP info to footer

### DIFF
--- a/templates/site/footer.html
+++ b/templates/site/footer.html
@@ -1,6 +1,6 @@
 <footer>
     <p>
-        Please report any problems on our <a href="https://github.com/PCMDI/cmip6-publication-site/issues" target="_blank">Github Issues</a> page. <br>
+        Please report any problems on our <a href="https://github.com/PCMDI/cmip6-publication-site/issues" target="_blank">Github Issues</a> page. | Learn about the Department of Energy's <a href="https://doe.responsibledisclosure.com/hc/en-us" target="_blank">Vulnerability Disclosure Program</a> <br>
         <small>
             Prepared by <a href="https://www.llnl.gov" target="_blank">Lawrence Livermore National Laboratory</a> under Contract DE-AC52-07NA27344 | <a href="https://www.llnl.gov/disclaimer" target="_blank">Privacy & Legal Notice</a> | LLNL-WEB-823400
         </small>


### PR DESCRIPTION
Resolves #163
 
Adds [Vulnerability Disclosure Program](https://doe.responsibledisclosure.com/hc/en-us) link to the footer.
![Screenshot 2022-02-22 at 12-45-11 Publication Hub](https://user-images.githubusercontent.com/42009431/155216640-4a296c88-b085-423c-81ca-bdf520191550.png)
