### PR TITLE
Add journals

### DIFF
--- a/scripts/journals.py
+++ b/scripts/journals.py
@@ -90,6 +90,7 @@ journal_names = [
     "Nature Climate Change",
     "Nature Communications",
     "Nature Geoscience",
+    "Nature Reviews Earth &amp; Environment",
     "Nonlinear Processes in Geophysics",
     "Nuclear Science Engineering",
     "Ocean Modelling",

--- a/scripts/journals.py
+++ b/scripts/journals.py
@@ -29,6 +29,7 @@ journal_names = [
     "Climate of the Past",
     "Climate of the Past Discussions",
     "Climatic Change",
+    "Communications Earth &amp; Environment",
     "Conservation Science and Practice",
     "Contributions to Atmospheric Physics",
     "Current Science",


### PR DESCRIPTION
Resolves #197, #196 

Adds the following journals:

- [Communications Earth & Environment](https://www.nature.com/commsenv/) (Shows as `Communications Earth &amp; Environment` in list)
- [Nature Reviews Earth and Environment](https://www.nature.com/natrevearthenviron/) (Shows as `Nature Reviews Earth &amp; Environment` in list)

`&amp;` is used instead of `&` as that is what is used in the containter-title of the DOI's JSON.  We can try to properly render the ampersand in the future.