### PR TITLE
Update VDP link

### DIFF
--- a/templates/site/footer.html
+++ b/templates/site/footer.html
@@ -1,6 +1,6 @@
 <footer>
     <p>
-        Please report any problems on our <a href="https://github.com/PCMDI/cmip6-publication-site/issues" target="_blank">Github Issues</a> page. | Learn about the Department of Energy's <a href="https://doe.responsibledisclosure.com/hc/en-us" target="_blank">Vulnerability Disclosure Program</a> <br>
+        Please report any problems on our <a href="https://github.com/PCMDI/cmip6-publication-site/issues" target="_blank">Github Issues</a> page. | Learn about the Department of Energy's <a href="https://www.energy.gov/vulnerability-disclosure-policy" target="_blank">Vulnerability Disclosure Program</a> <br>
         <small>
             Prepared by <a href="https://www.llnl.gov" target="_blank">Lawrence Livermore National Laboratory</a> under Contract DE-AC52-07NA27344 | <a href="https://www.llnl.gov/disclaimer" target="_blank">Privacy & Legal Notice</a> | LLNL-WEB-823400
         </small>


### PR DESCRIPTION
Use new [Vulnerability Disclosure Program](https://www.energy.gov/vulnerability-disclosure-policy) link.