### PR TITLE
Add journal 'Journal of Geophysical Research: Atmospheres'

### DIFF
--- a/scripts/journals.py
+++ b/scripts/journals.py
@@ -76,6 +76,7 @@ journal_names = [
     "Journal of Climate",
     "Journal of Geophysical Research",
     "Journal of Geophysical Research-Atmospheres",
+    "Journal of Geophysical Research: Atmospheres",
     "Journal of Geophysical Research: Oceans",
     "Journal of Hydrometeorology",
     "Journal of Molecular Structure",


### PR DESCRIPTION
@durack1 There is an alternate version of this journal's name in the database that has a hyphen instead of a colon.  If that version doesn't have any entries, then I'll remove it.